### PR TITLE
remove angular warning  - template is legacy

### DIFF
--- a/src/lib/components/tour-step-template.component.ts
+++ b/src/lib/components/tour-step-template.component.ts
@@ -8,7 +8,7 @@ import {TourStepTemplateService} from "../services/tour-step-template.service";
   selector: 'tour-step-template',
   styles: ['body { max-height: 100vh; }'],
   template: `
-     <template #tourStep let-step="step">
+     <ng-template #tourStep let-step="step">
      <span class="close-tour" (click)="tourService.end()"></span>
      <p class="title"> {{step?.title}}</p>
       <p class="tour-step-content " [innerHTML]="step.content"></p>
@@ -17,7 +17,7 @@ import {TourStepTemplateService} from "../services/tour-step-template.service";
         <button *ngIf="step.showNext && tourService.hasNext(step)" class="btn-color btn btn-sm btn-default" (click)="tourService.next()">Next »</button>
         <button *ngIf="step.showFinish" class="btn-color btn btn-sm" (click)="tourService.end()">Finish Tour</button>
       </div>
-    </template>
+    </ng-template>
   `,
 })
 export class TourStepTemplateComponent implements AfterViewInit {


### PR DESCRIPTION
core.es5.js:2933 Template parse warnings:
The <template> element is deprecated. Use <ng-template> instead ("
     [WARNING ->]<template #tourStep let-step="step">
     <span class="close-tour" (click)="tourService.end()"></span"): ng:///BmTourModule/TourStepTemplateComponent.html@1:5